### PR TITLE
Fix parameter in Uri Templates

### DIFF
--- a/src/Sinch.WebApiClient/WebClientRequestInterceptor.cs
+++ b/src/Sinch.WebApiClient/WebClientRequestInterceptor.cs
@@ -98,7 +98,7 @@ namespace Sinch.WebApiClient
 
             var uriTemplate = new Uri(new Uri(_baseUri, invocation.Method.DeclaringType.GetTypeInfo().GetCustomAttribute<RouteAttribute>()?.Value ?? string.Empty), httpAttribute.Route);
 
-            var template = new UriTemplate(uriTemplate.ToString());
+            var template = new UriTemplate(uriTemplate.ToString(), false, true);
             AddUriParameters(invocation.Method, template, invocation.Arguments);
             var uri = template.Resolve();
 
@@ -134,8 +134,7 @@ namespace Sinch.WebApiClient
 
                 foreach (var property in arguments[i].GetType().GetProperties())
                 {
-                    uriTemplate.SetParameter(property.Name, 
-                        string.Format(CultureInfo.InvariantCulture, "{0}", property.GetValue(arguments[i])));
+                    uriTemplate.SetParameter(property.Name, string.Format(CultureInfo.InvariantCulture, "{0}", property.GetValue(arguments[i])));
                 }
             }
         }


### PR DESCRIPTION
Bug in how the Tavis Uri resolver is being used.  The parameter names
are coming off upper case from the class properties which fail to
resolve by default.  I changed the overload to accept case invarient
parameter names so they will resolve correctly.  This will pair with a PR I am submitting for the Server SDK to fix some of the parameter encoding and make this functional on .NET core